### PR TITLE
Enable/Disable handling of online/offline event

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bower install jquery-atmosphere
 
 Full API documentation can be read [here](https://github.com/Atmosphere/atmosphere/wiki/jQuery.atmosphere.js-atmosphere.js-API) and a lot of samples [here](https://github.com/Atmosphere/atmosphere-samples)
 
-* 2.2.12+ => Tested with Atmosphere Runtime 2.2.7 , may have some regression with lower version
+* 2.2.12+ => Tested with Atmosphere Runtime 2.2.7+, 2.3.x, 2.4.x, 3.0.x , may have some regression with lower version
 * 2.2.1+ => Tested with Atmosphere Runtime 2.2.x , may work with lower version
 * 2.1.x  => Tested with Atmosphere Runtime 2.1.x , may work with lower version
 * 2.0.x  => Tested with Atmosphere Runtime 2.0.x and 1.0.13+


### PR DESCRIPTION
As part of investigating https://github.com/Atmosphere/atmosphere-javascript/issues/176 (still unresolved), I noticed that even under normal circumstances there is duplication at the app level and the library level for dealing with online/offline events.

In my app, there are a number of coordinated actions that need to be handled with online/offline, not just auto reconnecting the websocket.  It would be handy for an app to be able to disable atmosphere's default handling in some cases since it generates noise.

Would be happy to adjust this change stylistically.